### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     types: [opened, synchronize]
  
+permissions:
+  contents: read
+ 
 jobs:
   build:
     name: Build and Test


### PR DESCRIPTION
Potential fix for [https://github.com/theme-shoka-x/ShokaX-UI-Kit/security/code-scanning/2](https://github.com/theme-shoka-x/ShokaX-UI-Kit/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are appropriate:
- `contents: read` for reading repository contents during the `actions/checkout` step.
- `pull-requests: write` if the workflow interacts with pull requests (though this is not evident in the current workflow).

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the `build` job to limit permissions specifically for that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
